### PR TITLE
Added instantaneous mole fraction output at the end of each month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+Use this section to keep track of any intermediate changes that can then be moved to a versioned section.
+
+## [0.2.0] - 2021-XX-XX
+### Added
+- Instantaneous mole fraction is now output for the end of each month.
+Note that this is a breaking change, as one more return value is added to the 
+core model output tuple
+- Methods to change the start and end year of the simulation: 
+Model.change_start_year and Model.change_end_year
+
+### Changed
+- Due to the restart output being added, an additional return value is added
+to core.model
+
+### Removed
+- N/A

--- a/py12box/core.py
+++ b/py12box/core.py
@@ -197,19 +197,22 @@ def model(ic, q, mol_mass, lifetime,
 
     Returns
     -------
-    c_month : ndarray
+    ndarray
         2d, n_months x output_boxes
-        Mole fractions (pmol/mol).
-    burden : ndarray
+        Monthly mean mole fractions (pmol/mol).
+    ndarray
+        2d, n_months x output_boxes
+        Instantaneous mole fraction at final step of each month (pmol/mol).
+    ndarray
         2d, n_months x n_box
         The monthly-average global burden (g).
-    emissions : ndarray
+    ndarray
         2d, n_months x n_box
         The monthly-average mass emissions (g).
-    losses : ndarray
+    ndarray
         3d, n_resolved_losses x n_months x n_box.
         The monthly-average mass loss (g).
-    lifetimes : dict
+    dict
         3d, (n_resolved_losses+total) x n_months x n_box.
         Lifetimes calculated from individual time steps (year).
     
@@ -281,6 +284,8 @@ def model(ic, q, mol_mass, lifetime,
     # =========================================================================
     #     Output Arrays
     # =========================================================================
+    c_restart = np.zeros((n_months, n_box))
+    
     c_month = np.zeros((n_months, n_box))
     cnt_month = np.zeros((n_months, n_box))
     cnt_global_month = np.zeros(n_months)
@@ -381,6 +386,8 @@ def model(ic, q, mol_mass, lifetime,
         cnt_mi += 1
 
         if mi_ti_cnt == mi_ti - 1:
+            c_restart[mi] = c
+
             # Write Monthly totals for averages
             c_month[mi] = c_mi
             cnt_month[mi] += cnt_mi
@@ -408,6 +415,8 @@ def model(ic, q, mol_mass, lifetime,
 
     mole_fraction_out = np.divide(burden_out / mol_mass * mol_m_air * 1.0e12, mass)  # ppt
 
+    mole_fraction_restart = np.divide(c_restart / mol_mass * mol_m_air * 1.0e12, mass)  # ppt
+
     # Emissions in g
     q_out = q_g * mi_ti  # g
 
@@ -427,4 +436,4 @@ def model(ic, q, mol_mass, lifetime,
                  "cl": lifetime_cl / cnt_month / year_to_sec,
                  "other": lifetime_other / cnt_month / year_to_sec}
 
-    return mole_fraction_out, burden_out, q_out, losses, global_lifetimes
+    return mole_fraction_out, mole_fraction_restart, burden_out, q_out, losses, global_lifetimes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,11 +42,13 @@ def test_change_start_year():
     assert box_mod.time.shape[0] == box_mod.temperature.shape[0]
     if hasattr(box_mod, "mf"):
         assert box_mod.time.shape[0] == box_mod.mf.shape[0]
+        assert box_mod.time.shape[0] == box_mod.mf_restart.shape[0]
         assert box_mod.time.shape[0] == box_mod.burden.shape[0]
         for key, val in box_mod.losses.items():
             assert box_mod.time.shape[0] == val.shape[0]
         for key, val in box_mod.instantaneous_lifetimes.items():
             assert box_mod.time.shape[0] == val.shape[0]
+
 
 def test_change_end_year():
 
@@ -64,8 +66,19 @@ def test_change_end_year():
     assert box_mod.time.shape[0] == box_mod.temperature.shape[0]
     if hasattr(box_mod, "mf"):
         assert box_mod.time.shape[0] == box_mod.mf.shape[0]
+        assert box_mod.time.shape[0] == box_mod.mf_restart.shape[0]
         assert box_mod.time.shape[0] == box_mod.burden.shape[0]
         for key, val in box_mod.losses.items():
             assert box_mod.time.shape[0] == val.shape[0]
         for key, val in box_mod.instantaneous_lifetimes.items():
             assert box_mod.time.shape[0] == val.shape[0]
+
+def test_restart():
+
+    assert box_mod.mf_restart.shape == box_mod.mf.shape
+
+    # The restart values should be between the bracketing monthly means
+    assert (box_mod.mf[0,:4].mean() <= box_mod.mf_restart[0,:4].mean() <= box_mod.mf[1,:4].mean()) or \
+            (box_mod.mf[0,:4].mean() >= box_mod.mf_restart[0,:4].mean() >= box_mod.mf[1,:4].mean())
+    assert (box_mod.mf[20,:4].mean() <= box_mod.mf_restart[20,:4].mean() <= box_mod.mf[21,:4].mean()) or \
+            (box_mod.mf[20,:4].mean() >= box_mod.mf_restart[20,:4].mean() >= box_mod.mf[21,:4].mean())


### PR DESCRIPTION
This will allow us to use it as a restart value. 

change_start_year now uses the restart value as the new self.ic

This addresses, but doesn't completely fix, issue #8. To resolve that issue, we'd also need to add a non-zero starting timestep (maybe we don't need that?)