### PR TITLE
Fix to adjust emissions to 1/12ths of year if not

### DIFF
--- a/py12box/model.py
+++ b/py12box/model.py
@@ -315,7 +315,6 @@ class Model:
 
             # Find which timestep to start at
             ti = bisect(self.time, start_year) - 1
-
             # Trim input arrays
             self.time = self.time[ti:]
             self.emissions = self.emissions[ti:, :]
@@ -324,7 +323,6 @@ class Model:
             self.oh = self.oh[ti:, :]
             self.cl = self.cl[ti:, :]
             self.F = self.F[ti:, :, :]
-
             # Initial conditions
             if ti > 0:
                 self.ic = self.mf_restart[ti-1, :]
@@ -351,8 +349,6 @@ class Model:
             Note that the simulation will be trimmed before the beginning of end_year.
             I.e. end_year=2001. will curtail the simulation at the end of December 2000.
         """
-
-        #if float(end_year) < self.time[-1]:
         if np.isclose(end_year, self.time[-1]) or float(end_year) < self.time[-1]:
             # Trim at new end date
             ti = bisect(self.time, float(end_year)) #- 1

--- a/py12box/startup.py
+++ b/py12box/startup.py
@@ -163,9 +163,14 @@ def get_emissions(species, project_directory):
         time = np.arange(time_in[0], time_in[-1] + 1, 1 / 12.)
         emissions = np.repeat(emissions_df.values, 12, axis=0)
     else:
-        # Check for contiguous entries
-        if not np.allclose(time_in[1:]-time_in[:-1],1./12.):
+        # Check for contiguous entries and
+        # Change to decimal year in 1/12ths if otherwise
+        if np.allclose(time_in[1:]-time_in[:-1],1./12., atol=0.0001):
+            if not np.allclose(time_in[1:]-time_in[:-1],1./12.):
+                time_in = np.arange(np.floor(time_in[0]), np.ceil(time_in[-1]), 1./12.)
+        else:
             raise Exception("Missing or duplicate months in emissions")
+        
         # Assume monthly emissions
         time = time_in.copy()
         emissions = emissions_df.values


### PR DESCRIPTION
Currently the box model all works in 1/12ths of years.
This caused issues if the emissions were in proper decimal years (i.e. in days) as stuff would become misaligned. 

Fix was to just make sure monthly emissions are in 1/12 of years if monthly. Probably better to somehow make it handle this better but this is by far the quickest fix.

Plus a couple of commented lines were deleted.