### PR TITLE
Fix for #18 (test failing with end year)

### DIFF
--- a/py12box/model.py
+++ b/py12box/model.py
@@ -357,7 +357,7 @@ class Model:
         """
         if np.isclose(end_year, self.time[-1]) or float(end_year) < self.time[-1]:
             # Trim at new end date
-            ti = bisect(self.time, float(end_year)) #- 1
+            ti = bisect(self.time, float(end_year)) - 1
             self.time = self.time[:ti]
             self.emissions = self.emissions[:ti, :]
             self.lifetime = self.lifetime[:ti, :]


### PR DESCRIPTION
Fixes test failing. Problem with how end_years trimmed. Only seemed to cause a problem if year was equal to the final year in emissions problem but required changes to both py12box and py12box_invert.
Fixed test and issue #18 